### PR TITLE
當遇到大量(超過1000筆數)的相冊時的bug修復

### DIFF
--- a/EHentaiChromeExtension/popup.js
+++ b/EHentaiChromeExtension/popup.js
@@ -82,10 +82,10 @@ function extractNumGalleryPages(html) {
   var doc = htmlToDOM(html, '');
   var elements = doc.getElementsByClassName('gpc');
   var pageInfoStr = elements[0].innerHTML;
-  var patternImageNumbers = /Showing 1 - (\d+) of (\d+) images/;
+  var patternImageNumbers = /Showing 1 - (\d+) of (\d*,*\d+) images/;
   patternImageNumbers.exec(pageInfoStr);
   pageInfo.numImagesPerPage = RegExp.$1;
-  pageInfo.totalNumImages = RegExp.$2;
+  pageInfo.totalNumImages = (RegExp.$2).replace(",","");
   if (pageInfo.numImagesPerPage != null && pageInfo.totalNumImages != null) {
     pageInfo.numPages = Math.ceil(parseInt(pageInfo.totalNumImages) /
                                   parseInt(pageInfo.numImagesPerPage));


### PR DESCRIPTION
當遇到大量(超過1000筆數)的相冊時，會因為 1,000 而產生bug，
造成忽略已設定的下載間隔然後一秒鐘下載數十張，間接導致被ban

我只修改了正規表示式和文字取代的部分。
已測試過在8筆資料相冊、100筆資料的相冊和1000筆資料的相冊中運行正常。