### PR TITLE
Add options , save images as image numbers

### DIFF
--- a/EHentaiChromeExtension/options.html
+++ b/EHentaiChromeExtension/options.html
@@ -37,6 +37,11 @@
         </td>
       </tr>
       <tr>
+        <td>Save original images number as filename:</td>
+        <td><input type="checkbox" id="saveImageNumAsFilename"
+          name="saveImageNumAsFilename">Enable</td>
+      </tr>
+      <tr>
         <td>Filename conflict action:</td>
         <td colspan="2">
           <table style="border-spacing: 0px">

--- a/EHentaiChromeExtension/options.js
+++ b/EHentaiChromeExtension/options.js
@@ -6,6 +6,7 @@ var DEFAULT_INTERMEDIATE_DOWNLOAD_PATH = 'e-hentai helper/';
 var DEFAULT_SAVE_ORIGINAL_IMAGES = false;
 var DEFAULT_SAVE_GALLERY_INFO = false;
 var DEFAULT_SAVE_GALLERY_TAGS = false;
+var DEFAULT_SAVE_IMAGENUM_AS_FILENAME = false;
 var DEFAULT_FILENAME_CONFLICT_ACTION = 'uniquify';
 var DEFAULT_DOWNLOAD_INTERVAL = 300;  // In ms.
 
@@ -14,6 +15,7 @@ var inputIntermediateDownloadPath = null;
 var inputSaveOriginalImages = null;
 var inputSaveMetadataInfo = null;
 var inputSaveMetadataTags = null;
+var inputSaveImageNumAsFilename = null;
 var inputFilenameConflictActionUniquify = null;
 var inputFilenameConflictActionOverwrite = null;
 var inputDownloadInterval = null;
@@ -70,6 +72,7 @@ function restoreOptions() {
     saveOriginalImages:       DEFAULT_SAVE_ORIGINAL_IMAGES,
     saveGalleryInfo:          DEFAULT_SAVE_GALLERY_INFO,
     saveGalleryTags:          DEFAULT_SAVE_GALLERY_TAGS,
+    saveImageNumAsFilename:   DEFAULT_SAVE_IMAGENUM_AS_FILENAME,
     filenameConflictAction:   DEFAULT_FILENAME_CONFLICT_ACTION,
     downloadInterval:         DEFAULT_DOWNLOAD_INTERVAL
   }, function(items) {  // Update UI.
@@ -77,6 +80,7 @@ function restoreOptions() {
     inputSaveOriginalImages.checked = items.saveOriginalImages;
     inputSaveMetadataInfo.checked = items.saveGalleryInfo;
     inputSaveMetadataTags.checked = items.saveGalleryTags;
+    inputSaveImageNumAsFilename.checked = items.saveImageNumAsFilename;
     if (items.filenameConflictAction ==
         inputFilenameConflictActionUniquify.value) {
       inputFilenameConflictActionUniquify.checked = true;
@@ -93,6 +97,7 @@ function saveOptions() {
   var saveOriginalImages = inputSaveOriginalImages.checked;
   var saveGalleryInfo = inputSaveMetadataInfo.checked;
   var saveGalleryTags = inputSaveMetadataTags.checked;
+  var saveImageNumAsFilename = inputSaveImageNumAsFilename.checked;
   var filenameConflictAction = getFilenameConflictAction();
   var downloadInterval = inputDownloadInterval.value;
   intermediateDownloadPath = processFilePath(intermediateDownloadPath);
@@ -108,6 +113,7 @@ function saveOptions() {
     saveOriginalImages:       saveOriginalImages,
     saveGalleryInfo:          saveGalleryInfo,
     saveGalleryTags:          saveGalleryTags,
+    saveImageNumAsFilename:   saveImageNumAsFilename,
     filenameConflictAction:   filenameConflictAction,
     downloadInterval:         downloadInterval
   }, function() {  // Show a feedback message to user.
@@ -121,6 +127,7 @@ document.addEventListener('DOMContentLoaded', function() {
   inputSaveOriginalImages = document.getElementById('saveOriginalImages');
   inputSaveMetadataInfo = document.getElementById('saveMetadataInfo');
   inputSaveMetadataTags = document.getElementById('saveMetadataTags');
+  inputSaveImageNumAsFilename = document.getElementById('saveImageNumAsFilename');
   inputFilenameConflictActionUniquify =
     document.getElementById('filenameConflictActionUniquify');
   inputFilenameConflictActionOverwrite =

--- a/EHentaiChromeExtension/popup.js
+++ b/EHentaiChromeExtension/popup.js
@@ -264,8 +264,10 @@ function generateTxtFile(text) {
 chrome.downloads.onDeterminingFilename.addListener(
     function(downloadItem, suggest) {
       if (downloadItem.byExtensionName == EXTENSION_NAME) {
-        var imageIndex = downloadItem.url.substring(downloadItem.url.lastIndexOf('@')+1);
-        downloadItem.url = downloadItem.url.substring(0,downloadItem.url.lastIndexOf('@')-1);
+        if(downloadItem.url.indexOf('@')!=-1){
+          var imageIndex = downloadItem.url.substring(downloadItem.url.lastIndexOf('@')+1);
+          downloadItem.url = downloadItem.url.substring(0,downloadItem.url.lastIndexOf('@'));
+        }
         var filename = downloadItem.filename;
         var fileType = filename.substring(filename.lastIndexOf('.') + 1);
         if (fileType == 'txt') {  // Metadata.

--- a/EHentaiChromeExtension/popup.js
+++ b/EHentaiChromeExtension/popup.js
@@ -221,21 +221,21 @@ function processImagePage(url,imageIndex) {
         imageUrl = divDownloadOriginal.childNodes[3].href;
       }
     }
-    chrome.downloads.download({url: imageUrl+"@"+imageIndex});
+    chrome.downloads.download({url: imageUrl+"@"+imageIndex}); // add delimiter
   });
 }
 
 function processGalleryPage(url,pageIndex) {
   httpGetAsync(url, function(responseText) {
     var imagePageUrls = extractImagePageUrls(responseText);
-    processImagePage(imagePageUrls[0],pageIndex*40);  // Start immediately.
+    processImagePage(imagePageUrls[0], pageIndex*40 );  // Start immediately.
     var imageIndex = 1;
     var imageInterval = setInterval(function() {
       if(imageIndex == imagePageUrls.length) {
         clearInterval(imageInterval);
         return;
       }
-      processImagePage(imagePageUrls[imageIndex],pageIndex*40+imageIndex);
+      processImagePage(imagePageUrls[imageIndex], pageIndex*40 + imageIndex );
       imageIndex++;
     }, downloadInterval);
   });
@@ -261,13 +261,11 @@ function generateTxtFile(text) {
 }
 
 // Save to the corresponding folder and rename files.
-// var saveImageNumAsFilenameCounter = 0;
 chrome.downloads.onDeterminingFilename.addListener(
     function(downloadItem, suggest) {
       if (downloadItem.byExtensionName == EXTENSION_NAME) {
         var imageIndex = downloadItem.url.substring(downloadItem.url.lastIndexOf('@')+1);
         downloadItem.url = downloadItem.url.substring(0,downloadItem.url.lastIndexOf('@')-1);
-        console.log(imageIndex , downloadItem.url);
         var filename = downloadItem.filename;
         var fileType = filename.substring(filename.lastIndexOf('.') + 1);
         if (fileType == 'txt') {  // Metadata.
@@ -276,7 +274,7 @@ chrome.downloads.onDeterminingFilename.addListener(
           var isInfoFile = url.substring(url.indexOf(',') + 1)
                               .startsWith('name');
           filename = isInfoFile ? 'info.txt' : 'tags.txt';
-        }else if (1/*saveImageNumAsFilename*/) {
+        }else if (saveImageNumAsFilename) {
           filename = "pic_" + ('0000' + imageIndex).slice(-4) + "." + fileType;
         }
         filename = intermediateDownloadPath + '/' + filename;

--- a/EHentaiChromeExtension/popup.js
+++ b/EHentaiChromeExtension/popup.js
@@ -9,6 +9,7 @@ var DEFAULT_INTERMEDIATE_DOWNLOAD_PATH = 'e-hentai helper/';
 var DEFAULT_SAVE_ORIGINAL_IMAGES = false;
 var DEFAULT_SAVE_GALLERY_INFO = false;
 var DEFAULT_SAVE_GALLERY_TAGS = false;
+var DEFAULT_SAVE_IMAGENUM_AS_FILENAME = false;
 var DEFAULT_FILENAME_CONFLICT_ACTION = 'uniquify';
 var DEFAULT_DOWNLOAD_INTERVAL = 300;  // In ms.
 
@@ -17,6 +18,7 @@ var intermediateDownloadPath = DEFAULT_INTERMEDIATE_DOWNLOAD_PATH;
 var saveOriginalImages = DEFAULT_SAVE_ORIGINAL_IMAGES;
 var saveGalleryInfo = DEFAULT_SAVE_GALLERY_INFO;
 var saveGalleryTags = DEFAULT_SAVE_GALLERY_TAGS;
+var saveImageNumAsFilename = DEFAULT_SAVE_IMAGENUM_AS_FILENAME;
 var filenameConflictAction = DEFAULT_FILENAME_CONFLICT_ACTION;
 var downloadInterval = DEFAULT_DOWNLOAD_INTERVAL;
 
@@ -259,6 +261,7 @@ function generateTxtFile(text) {
 }
 
 // Save to the corresponding folder and rename files.
+var saveImageNumAsFilenameCounter = 0;
 chrome.downloads.onDeterminingFilename.addListener(
     function(downloadItem, suggest) {
       if (downloadItem.byExtensionName == EXTENSION_NAME) {
@@ -270,6 +273,8 @@ chrome.downloads.onDeterminingFilename.addListener(
           var isInfoFile = url.substring(url.indexOf(',') + 1)
                               .startsWith('name');
           filename = isInfoFile ? 'info.txt' : 'tags.txt';
+        }else if (saveImageNumAsFilename) {
+          filename = "pic_" + ('0000' + saveImageNumAsFilenameCounter++).slice(-4) + "." + fileType;
         }
         filename = intermediateDownloadPath + '/' + filename;
         suggest({
@@ -312,6 +317,7 @@ document.addEventListener('DOMContentLoaded', function() {
     saveOriginalImages:       DEFAULT_SAVE_ORIGINAL_IMAGES,
     saveGalleryInfo:          DEFAULT_SAVE_GALLERY_INFO,
     saveGalleryTags:          DEFAULT_SAVE_GALLERY_TAGS,
+    saveImageNumAsFilename:   DEFAULT_SAVE_IMAGENUM_AS_FILENAME,
     filenameConflictAction:   DEFAULT_FILENAME_CONFLICT_ACTION,
     downloadInterval:         DEFAULT_DOWNLOAD_INTERVAL
   }, function(items) {
@@ -319,6 +325,7 @@ document.addEventListener('DOMContentLoaded', function() {
     saveOriginalImages = items.saveOriginalImages;
     saveGalleryInfo = items.saveGalleryInfo;
     saveGalleryTags = items.saveGalleryTags;
+    saveImageNumAsFilename = items.saveImageNumAsFilename;
     filenameConflictAction = items.filenameConflictAction;
     downloadInterval = items.downloadInterval;
 


### PR DESCRIPTION
Implement the options which can save images using their image number.
Because some gallery using hash as their file name , ex : 00as97df9gfds89asfa0.jpg.
issue #4 

so , I implement the options that can save the original images number as filename.
And tested under 200+images gallery.

I downloaded same gallery for 3 times , filename conflicts using uniquify , Download interval : 300.
And result shows the page number is correct , doesn't occur sequence error . 💯 
